### PR TITLE
Update Dockerfile to prevent 'No working compiler found' error during…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.5.2-alpine
 
 COPY ./ /opt/local/src/VestaService/
 
+RUN apk add --no-cache --virtual .py_deps build-base python3-dev libffi-dev openssl-dev
+
 RUN pip install /opt/local/src/VestaService/
 
 USER 1000


### PR DESCRIPTION
Update Dockerfile to prevent 'No working compiler found' error during cffi installation.
Solution taken from https://github.com/miguelgrinberg/microblog/issues/121 who had similar issue
